### PR TITLE
Linting package on CI

### DIFF
--- a/.earthignore
+++ b/.earthignore
@@ -1,0 +1,3 @@
+.eldev
+.git
+.gitignore

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,21 @@
+name: GitHub Action CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: +lint
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs_version: ["26", "27"]
+    steps:
+      - uses: earthly/actions/setup-earthly@v1
+      - uses: actions/checkout@v2
+      - name: +lint
+        run: earthly --use-inline-cache +lint --EMACS_VERSION=${{ matrix.emacs_version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Added automatically by ‘eldev init’.
+/.eldev
+/Eldev-local

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,6 @@
+lint:
+	ARG EMACS_VERSION=26
+	FROM silex/emacs:${EMACS_VERSION}-alpine-ci-eldev
+	WORKDIR /earthly-mode
+	COPY . /earthly-mode/
+	RUN eldev lint

--- a/Eldev
+++ b/Eldev
@@ -1,0 +1,7 @@
+; -*- mode: emacs-lisp; lexical-binding: t -*-
+
+;; Uncomment some calls below as needed for your project.
+;(eldev-use-package-archive 'gnu)
+;(eldev-use-package-archive 'melpa)
+
+(eldev-use-plugin 'autoloads)


### PR DESCRIPTION
This changes introduce Eldev to uses for lingting the package and add
Earthfile to run Eldev inside the container. And add GitHub workflow
to run linting against Earthly.

The CI workflow run on 2 Emacs version, 26 which's minimum support and
27 which's latest stable version.

You can see an example [here](https://github.com/wingyplus/earthly-mode-1/actions/runs/1179059981).

Closes #5